### PR TITLE
fixed methods names for calling channel ID and permission check for VCID

### DIFF
--- a/VCID/build.gradle.kts
+++ b/VCID/build.gradle.kts
@@ -1,2 +1,2 @@
-version = "1.1.2"
+version = "1.1.3"
 description = "VCID"

--- a/VCID/src/main/java/com/aliucord/plugins/VCID.java
+++ b/VCID/src/main/java/com/aliucord/plugins/VCID.java
@@ -34,7 +34,7 @@ public class VCID extends Plugin {
         // add the patch
         patcher.patch(WidgetChannelsListAdapter.ItemChannelVoice.class.getDeclaredMethod("onConfigure", int.class, ChannelListItem.class), new Hook(callFrame -> {
             var channel = (ChannelListItemVoiceChannel) callFrame.args[1];
-            if (PermissionUtils.can(16, channel.component1().g())) return;
+            if (PermissionUtils.can(16, channel.component1().k())) return;
 
             try {
                 var binding = (WidgetChannelsListItemChannelVoiceBinding) itemClass.get(callFrame.thisObject);

--- a/VCID/src/main/java/com/aliucord/plugins/VCID.java
+++ b/VCID/src/main/java/com/aliucord/plugins/VCID.java
@@ -34,13 +34,13 @@ public class VCID extends Plugin {
         // add the patch
         patcher.patch(WidgetChannelsListAdapter.ItemChannelVoice.class.getDeclaredMethod("onConfigure", int.class, ChannelListItem.class), new Hook(callFrame -> {
             var channel = (ChannelListItemVoiceChannel) callFrame.args[1];
-            if (PermissionUtils.can(16, channel.component1().h())) return;
+            if (PermissionUtils.can(16, channel.component1().g())) return;
 
             try {
                 var binding = (WidgetChannelsListItemChannelVoiceBinding) itemClass.get(callFrame.thisObject);
                 binding.a.setOnLongClickListener(view -> {
                     android.content.ClipboardManager clipboard = (android.content.ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
-                    android.content.ClipData clip = android.content.ClipData.newPlainText("Copied to clipboard.", String.valueOf(channel.getChannel().h()));
+                    android.content.ClipData clip = android.content.ClipData.newPlainText("VCID", String.valueOf(channel.getChannel().k()));
                     int duration = Toast.LENGTH_SHORT;
                     Toast.makeText(context, "Copied to clipboard.", duration).show();
                     clipboard.setPrimaryClip(clip);
@@ -74,7 +74,7 @@ public class VCID extends Plugin {
             textView.setCompoundDrawablesWithIntrinsicBounds(R.e.ic_content_copy_white_a60_24dp, 0,0, 0);
             textView.setOnClickListener(view -> {
                 android.content.ClipboardManager clipboard = (android.content.ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
-                android.content.ClipData clip = android.content.ClipData.newPlainText("Copied to clipboard.", String.valueOf(model.getChannel().h()));
+                android.content.ClipData clip = android.content.ClipData.newPlainText("VCID", String.valueOf(model.getChannel().k()));
                 int duration = Toast.LENGTH_SHORT;
                 Toast.makeText(context, "Copied to clipboard.", duration).show();
                 clipboard.setPrimaryClip(clip);


### PR DESCRIPTION
Hi, i noticed this plugin wasn't working 
```
[Patcher] Exception while hooking com.discord.widgets.channels.list.WidgetChannelsListAdapter$ItemChannelVoice.onConfigure
java.lang.NoSuchMethodError: No virtual method h()J in class Lcom/discord/api/channel/Channel; or its super classes (declaration of 'com.discord.api.channel.Channel' appears in base.apk!classes2.dex)
  at com.aliucord.plugins.VCID.lambda$start$1(VCID.java:37)
  at com.aliucord.plugins.VCID$$ExternalSyntheticLambda3.call(Unknown Source:6)
  at com.aliucord.patcher.Hook.afterHookedMethod(Hook.kt:21)
  at de.robv.android.xposed.XposedBridge$HookInfo.callback(XposedBridge.java:381)
  at LSPHooker_.onConfigure(Unknown Source:18)
  at com.discord.widgets.channels.list.WidgetChannelsListAdapter$ItemChannelVoice.onConfigure(WidgetChannelsListAdapter.kt, [Patcher] Exception while hooking com.discord.widgets.channels.list.WidgetChannelsListAdapter$ItemChannelVoice.onConfigure:1)
  at com.discord.utilities.mg_recycler.MGRecyclerViewHolder.onBindViewHolder(MGRecyclerViewHolder.kt:3)
  at com.discord.utilities.mg_recycler.MGRecyclerAdapter.onBindViewHolder(MGRecyclerAdapter.kt:2)
  at com.discord.utilities.mg_recycler.MGRecyclerAdapter.onBindViewHolder(MGRecyclerAdapter.kt:1)
  at androidx.recyclerview.widget.RecyclerView$Adapter.onBindViewHolder(RecyclerView.java:1)
  at androidx.recyclerview.widget.RecyclerView$Adapter.bindViewHolder(RecyclerView.java:8)
  at androidx.recyclerview.widget.RecyclerView$Recycler.tryBindViewHolderByDeadline(RecyclerView.java:7)
``` 
so I fixed it. I am however not sure about the permission check thingie or whatever it's supposed to do; I assumed it should compare to channel flags or something :
```kt
if (PermissionUtils.can(16, channel.component1().g())) return;
``` 
with g() from Channel.java
```kt
public final Long g() {
        return this.flags;
    } 
```